### PR TITLE
feat: implement usage-based billing with oracle reporting (#3)

### DIFF
--- a/contracts/utility_contracts/src/lib.rs
+++ b/contracts/utility_contracts/src/lib.rs
@@ -1,12 +1,12 @@
 #![no_std]
-use soroban_sdk::{contract, contracttype, contractimpl, Address, Env, token};
+use soroban_sdk::{contract, contracttype, contractimpl, Address, Env, token, Symbol};
 
 #[contracttype]
 #[derive(Clone)]
 pub struct Meter {
     pub user: Address,
     pub provider: Address,
-    pub rate_per_second: i128,
+    pub rate_per_unit: i128,
     pub balance: i128,
     pub last_update: u64,
     pub is_active: bool,
@@ -17,6 +17,7 @@ pub struct Meter {
 pub enum DataKey {
     Meter(u64),
     Count,
+    Oracle,
 }
 
 #[contract]
@@ -24,6 +25,10 @@ pub struct UtilityContract;
 
 #[contractimpl]
 impl UtilityContract {
+    pub fn set_oracle(env: Env, oracle: Address) {
+        env.storage().instance().set(&DataKey::Oracle, &oracle);
+    }
+
     pub fn register_meter(
         env: Env,
         user: Address,
@@ -38,7 +43,7 @@ impl UtilityContract {
         let meter = Meter {
             user,
             provider,
-            rate_per_second: rate,
+            rate_per_unit: rate,
             balance: 0,
             last_update: env.ledger().timestamp(),
             is_active: false,
@@ -64,33 +69,40 @@ impl UtilityContract {
         env.storage().instance().set(&DataKey::Meter(meter_id), &meter);
     }
 
-    pub fn claim(env: Env, meter_id: u64) {
+    pub fn deduct_units(env: Env, meter_id: u64, units_consumed: i128) {
+        let oracle: Address = env.storage().instance().get(&DataKey::Oracle).expect("Oracle address not set");
+        oracle.require_auth();
+
         let mut meter: Meter = env.storage().instance().get(&DataKey::Meter(meter_id)).ok_or("Meter not found").unwrap();
-        meter.provider.require_auth();
-
-        let now = env.ledger().timestamp();
-        let elapsed = now.checked_sub(meter.last_update).unwrap_or(0);
-        let amount = (elapsed as i128) * meter.rate_per_second;
         
-        // Ensure we don't overdraw the balance
-        let claimable = if amount > meter.balance {
-            meter.balance
-        } else {
-            amount
-        };
+        let cost = units_consumed * meter.rate_per_unit;
+        
+        if cost > 0 {
+            let actual_claim = if cost > meter.balance {
+                meter.balance
+            } else {
+                cost
+            };
 
-        if claimable > 0 {
-            let client = token::Client::new(&env, &meter.token);
-            client.transfer(&env.current_contract_address(), &meter.provider, &claimable);
-            meter.balance -= claimable;
+            if actual_claim > 0 {
+                let client = token::Client::new(&env, &meter.token);
+                client.transfer(&env.current_contract_address(), &meter.provider, &actual_claim);
+                meter.balance -= actual_claim;
+            }
         }
 
-        meter.last_update = now;
+        meter.last_update = env.ledger().timestamp();
         if meter.balance <= 0 {
             meter.is_active = false;
         }
 
         env.storage().instance().set(&DataKey::Meter(meter_id), &meter);
+
+        // Emit UsageReported event
+        env.events().publish(
+            (Symbol::new(&env, "UsageReported"), meter_id),
+            (units_consumed, cost)
+        );
     }
 
     pub fn get_meter(env: Env, meter_id: u64) -> Option<Meter> {

--- a/contracts/utility_contracts/src/test.rs
+++ b/contracts/utility_contracts/src/test.rs
@@ -14,7 +14,11 @@ fn test_utility_flow() {
 
     let user = Address::generate(&env);
     let provider = Address::generate(&env);
+    let oracle = Address::generate(&env);
     
+    // Setup Oracle
+    client.set_oracle(&oracle);
+
     // Setup a token
     let token_admin = Address::generate(&env);
     let token_address = env.register_stellar_asset_contract(token_admin.clone());
@@ -25,12 +29,12 @@ fn test_utility_flow() {
     token_admin_client.mint(&user, &1000);
 
     // 1. Register Meter
-    let rate = 10; // 10 tokens per second
+    let rate = 10; // 10 tokens per unit (kWh)
     let meter_id = client.register_meter(&user, &provider, &rate, &token_address);
     assert_eq!(meter_id, 1);
 
     let meter = client.get_meter(&meter_id).unwrap();
-    assert_eq!(meter.rate_per_second, 10);
+    assert_eq!(meter.rate_per_unit, 10);
     assert_eq!(meter.balance, 0);
     assert_eq!(meter.is_active, false);
 
@@ -42,19 +46,19 @@ fn test_utility_flow() {
     assert_eq!(token.balance(&user), 500);
     assert_eq!(token.balance(&contract_id), 500);
 
-    // 3. Claim balance (simulate time passing)
-    env.ledger().set_timestamp(env.ledger().timestamp() + 10); // 10 seconds pass
-    client.claim(&meter_id);
+    // 3. Report usage (billing by units)
+    let units_consumed = 15; // 15 kWh
+    client.deduct_units(&meter_id, &units_consumed);
     
     let meter = client.get_meter(&meter_id).unwrap();
-    // 10 seconds * 10 tokens/sec = 100 tokens claimed
-    assert_eq!(meter.balance, 400);
-    assert_eq!(token.balance(&provider), 100);
-    assert_eq!(token.balance(&contract_id), 400);
+    // 15 units * 10 tokens/unit = 150 tokens claimed
+    assert_eq!(meter.balance, 350);
+    assert_eq!(token.balance(&provider), 150);
+    assert_eq!(token.balance(&contract_id), 350);
 
-    // 4. Claim more than balance
-    env.ledger().set_timestamp(env.ledger().timestamp() + 50); // 50 seconds pass
-    client.claim(&meter_id);
+    // 4. Report usage that exceeds balance
+    let more_units = 50; // 50 units * 10 = 500 cost, but only 350 left
+    client.deduct_units(&meter_id, &more_units);
 
     let meter = client.get_meter(&meter_id).unwrap();
     assert_eq!(meter.balance, 0);


### PR DESCRIPTION
#3.

### Implementation:
- **Oracle Storage**: Added [set_oracle](cci:1://file:///C:/Users/HP/Desktop/wv3/issue-5/contracts/utility_contracts/src/lib.rs:27:4-29:5) function to store a trusted oracle address.
- **Reporting Usage**: Implemented [deduct_units(meter_id, units_consumed)](cci:1://file:///C:/Users/HP/Desktop/wv3/issue-5/contracts/utility_contracts/src/lib.rs:71:4-105:5) function (restricted to Oracle) for recording and billing consumption.
- **Billing logic**: Renamed `rate_per_second` to `rate_per_unit` in [Meter](cci:2://file:///C:/Users/HP/Desktop/wv3/issue-5/contracts/utility_contracts/src/lib.rs:5:0-13:1) struct and updated [register_meter](cci:1://file:///C:/Users/HP/Desktop/wv3/issue-5/contracts/utility_contracts/src/lib.rs:31:4-55:5).
- **Events**: Implemented `UsageReported` event emission for better consumption tracking.
- **Refactoring**: Removed outdated time-based `claim` logic.
- **Testing**: Updated the test suite to include oracle setup and verify kWh-based billing.

Closes #3
