### PR TITLE
docs: add hardware spec integration guide for MQTT contract flow

### DIFF
--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -1,0 +1,53 @@
+# Hardware Spec Integration
+
+This project does not connect to MQTT brokers directly from the smart contract. The contract is the settlement layer, while a backend service listens for device telemetry over MQTT, validates the readings, and then submits authenticated transactions to the contract.
+
+## Architecture
+
+```text
++---------+       +--------+       +---------+       +------------------+
+|  Meter  | ----> |  MQTT  | ----> | Backend | ----> | Smart Contract   |
+| Device  |       | Broker |       | Service |       | (Soroban/Stellar)|
++---------+       +--------+       +---------+       +------------------+
+```
+
+## Connection Flow
+
+1. A smart meter or controller running on ESP32 or Raspberry Pi measures energy or utility consumption.
+2. The device publishes usage data to an MQTT topic such as `meters/{meter_id}/usage`.
+3. The backend service subscribes to the MQTT broker, parses the payload, and validates the device identity and reading format.
+4. The backend maps the hardware meter to an on-chain `meter_id`.
+5. The backend submits a signed contract call such as `deduct_units` or `update_usage`.
+6. The contract updates stored meter data, transfers value when required, and emits events for downstream monitoring.
+
+## MQTT Payload Example
+
+```json
+{
+  "meter_id": 1,
+  "timestamp": 1710000000,
+  "watt_hours_consumed": 250,
+  "units_consumed": 1
+}
+```
+
+## Supported Hardware Devices
+
+- ESP32 development boards with Wi-Fi and MQTT client support
+- ESP32-S3 boards for higher-performance edge processing
+- Raspberry Pi Zero 2 W for lightweight gateway deployments
+- Raspberry Pi 4 for local aggregation and MQTT forwarding
+- Raspberry Pi 5 for higher-throughput backend or gateway workloads
+
+## Suggested Responsibilities
+
+- Meter device: sample consumption data and publish telemetry
+- MQTT broker: route messages reliably between devices and backend services
+- Backend service: authenticate devices, validate readings, and call the contract
+- Smart contract: store meter state, handle balances, and enforce settlement rules
+
+## Notes
+
+- The smart contract should not hold MQTT credentials or broker connection logic.
+- MQTT authentication, TLS, retry handling, and device registry checks should live in the backend layer.
+- If an ESP32 is too resource-constrained for direct blockchain signing, it should publish to MQTT and let the backend submit the on-chain transaction.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ This repository uses the recommended structure for a Soroban project:
 - **Network:** Stellar Testnet
 - **Contract ID:** CB7PSJZALNWNX7NLOAM6LOEL4OJZMFPQZJMIYO522ZSACYWXTZIDEDSS
 
+## Additional Documentation
+- [Hardware Spec Integration](HARDWARE.md)


### PR DESCRIPTION

## Overview
This PR adds dedicated hardware integration documentation for the Utility Drip contract flow. It explains how ESP32 and Raspberry Pi devices connect indirectly to the smart contract through MQTT and a backend service, and documents the supported hardware options for this setup.

## Related Issue
Closes #10

## Changes

### 📘 Hardware Documentation
- **[ADD]** `HARDWARE.md`
  - Added a dedicated hardware integration guide for the project.
  - Documented how an ESP32 or Raspberry Pi sends telemetry through MQTT to a backend service that interacts with the smart contract.
  - Included the required architecture diagram:
    `Meter -> MQTT -> Backend -> Smart Contract`
  - Listed supported hardware devices relevant to this workflow.

### 🔗 Documentation Navigation
- **[MODIFY]** `README.md`
  - Added a link to `HARDWARE.md` so the new documentation is discoverable from the repo root.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Create `HARDWARE.md` | ✅ |
| Diagram: Meter -> MQTT -> Backend -> Smart Contract | ✅ |
| List supported hardware devices | ✅ |

## How to Test

```bash
# 1. Confirm you're on the branch
git branch --show-current

# 2. Open the hardware documentation
sed -n '1,200p' HARDWARE.md

# 3. Verify the README links to the new doc
sed -n '1,120p' README.md

# 4. Optional: inspect the changed files
git diff -- README.md HARDWARE.md
```

## Screenshots

### ✅ Hardware documentation added
A screenshot of:

```bash
sed -n '1,200p' HARDWARE.md
```
<img width="1016" height="356" alt="image" src="https://github.com/user-attachments/assets/27c81936-ef8e-426d-a65c-273902bc2fa5" />

### ✅ README links to hardware guide
A screenshot of:

```bash
sed -n '1,120p' README.md
```
<img width="1031" height="334" alt="image" src="https://github.com/user-attachments/assets/c9c7967a-8dd7-4e03-b398-04b293babef9" />
